### PR TITLE
Graph helper methods, e.g. Agency#stops

### DIFF
--- a/lib/gtfs/agency.rb
+++ b/lib/gtfs/agency.rb
@@ -13,5 +13,27 @@ module GTFS
     def id
       self.agency_id
     end
+
+    def stops
+      visited = Set.new
+      self.routes.each do |route|
+        route.trips.each do |trip|
+          visited |= trip.stops
+        end
+      end
+      visited
+    end
+
+    def trips
+      visited = Set.new
+      self.routes.each do |route|
+        visited |= route.trips
+      end
+      visited
+    end
+
+    def routes
+      self.feed.children(self)
+    end
   end
 end

--- a/lib/gtfs/route.rb
+++ b/lib/gtfs/route.rb
@@ -152,13 +152,25 @@ module GTFS
      :'1701' => :'Cable Car',
      :'1702' => :'Horse-drawn Carriage'
     }
-    
+
     def gtfs_vehicle_type
       VEHICLE_TYPES[self.route_type.to_s.to_sym]
     end
 
     def id
       self.route_id
+    end
+
+    def stops
+      visited = Set.new
+      self.trips.each do |trip|
+        visited |= trip.stops
+      end
+      visited
+    end
+
+    def trips
+      self.feed.children(self)
     end
   end
 end

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -94,7 +94,7 @@ module GTFS
         @cache[cls].values.each(&block)
       else
         @cache[cls] = {}
-        cls.each(file_path(filename), options) do |model|
+        cls.each(file_path(filename), options, self) do |model|
           @cache[cls][model.id || model] = model
           block.call model
         end
@@ -119,7 +119,7 @@ module GTFS
 
       # feed.each_<entity>
       define_method "each_#{cls.singular_name}".to_sym do |&block|
-        cls.each(file_path(cls.filename), options, &block)
+        cls.each(file_path(cls.filename), options, self, &block)
       end
     end
 
@@ -138,7 +138,6 @@ module GTFS
       start_dates = @service_periods.values.map(&:start_date)
       end_dates = @service_periods.values.map(&:end_date)
       [start_dates.min, end_dates.max]
-
     end
 
     ##### Load graph, shapes, calendars, etc. #####

--- a/lib/gtfs/trip.rb
+++ b/lib/gtfs/trip.rb
@@ -13,5 +13,9 @@ module GTFS
     def id
       self.trip_id
     end
+
+    def stops
+      self.feed.children(self)
+    end
   end
 end

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -119,6 +119,13 @@ describe GTFS::Source do
     end
   end
 
+  describe 'each_entity' do
+    let(:source) {GTFS::Source.build(valid_local_source)}
+    it 'entities maintain reference to feed' do
+      source.agencies.first.feed.should be source
+    end
+  end
+
   describe '#agencies' do
     subject {source.agencies}
 


### PR DESCRIPTION
Loaded entities retain a reference to their Source instance.

Provide graph helper methods for Agency, Route, Trip, and Stop.
