### PR TITLE
Archive timestamps

### DIFF
--- a/lib/gtfs.rb
+++ b/lib/gtfs.rb
@@ -20,3 +20,5 @@ require 'gtfs/zip_source'
 require 'gtfs/url_source'
 require 'gtfs/service_period'
 require 'gtfs/wide_time'
+
+require 'rubyzip_time'

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -294,16 +294,7 @@ module GTFS
       Zip::File.open(path, Zip::File::CREATE) do |zipfile|
         self.class::ENTITIES.each do |cls|
           next unless file_present?(cls.filename)
-          # zipfile.add(cls.filename, file_path(cls.filename))
-          # This is a very specialized need; we need to carry over
-          #   the file timestamps into the zip archive.
-          path = file_path(cls.filename)
-          entry = Zip::Entry.new(zipfile, cls.filename)
-          entry.gather_fileinfo_from_srcpath(path)
-          entry.instance_variable_set('@time', Zip::DOSTime.at(File.stat(path).mtime))
-          entry.dirty = true
-          entry_set = zipfile.instance_variable_get('@entry_set')
-          entry_set << entry
+          zipfile.add(cls.filename, file_path(cls.filename))
         end
       end
     end

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -288,10 +288,10 @@ module GTFS
       end
     end
 
-    def create_archive(path)
+    def create_archive(filename)
       # Create a new GTFS archive.
-      raise 'File exists' if File.exists?(path)
-      Zip::File.open(path, Zip::File::CREATE) do |zipfile|
+      raise 'File exists' if File.exists?(filename)
+      Zip::File.open(filename, Zip::File::CREATE) do |zipfile|
         self.class::ENTITIES.each do |cls|
           next unless file_present?(cls.filename)
           zipfile.add(cls.filename, file_path(cls.filename))
@@ -320,6 +320,7 @@ module GTFS
     private
 
     def load_archive(source)
+      # Return directory with GTFS CSV files
       source
     end
 

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -289,15 +289,18 @@ module GTFS
     end
 
     def create_archive(path)
+      # Create a new GTFS archive.
       raise 'File exists' if File.exists?(path)
       Zip::File.open(path, Zip::File::CREATE) do |zipfile|
         self.class::ENTITIES.each do |cls|
           next unless file_present?(cls.filename)
           # zipfile.add(cls.filename, file_path(cls.filename))
+          # This is a very specialized need; we need to carry over
+          #   the file timestamps into the zip archive.
+          path = file_path(cls.filename)
           entry = Zip::Entry.new(zipfile, cls.filename)
-          puts "entry: #{entry.time} - #{entry.name}"
-          entry.gather_fileinfo_from_srcpath(file_path(cls.filename))
-          entry.instance_variable_set('@time', Zip::DOSTime.parse('2016-01-01 01:02:03'))
+          entry.gather_fileinfo_from_srcpath(path)
+          entry.instance_variable_set('@time', Zip::DOSTime.at(File.stat(path).mtime))
           entry.dirty = true
           entry_set = zipfile.instance_variable_get('@entry_set')
           entry_set << entry

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -293,7 +293,14 @@ module GTFS
       Zip::File.open(path, Zip::File::CREATE) do |zipfile|
         self.class::ENTITIES.each do |cls|
           next unless file_present?(cls.filename)
-          zipfile.add(cls.filename, file_path(cls.filename))
+          # zipfile.add(cls.filename, file_path(cls.filename))
+          entry = Zip::Entry.new(zipfile, cls.filename)
+          puts "entry: #{entry.time} - #{entry.name}"
+          entry.gather_fileinfo_from_srcpath(file_path(cls.filename))
+          entry.instance_variable_set('@time', Zip::DOSTime.parse('2016-01-01 01:02:03'))
+          entry.dirty = true
+          entry_set = zipfile.instance_variable_get('@entry_set')
+          entry_set << entry
         end
       end
     end

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -299,14 +299,22 @@ module GTFS
       end
     end
 
-    def self.build(data_root, opts={})
-      if File.directory?(data_root)
-        src = Source.new(data_root, opts)
-      elsif File.exists?(data_root)
-        src = ZipSource.new(data_root, opts)
+    def self.build(source, opts={})
+      raise 'source required' unless source
+      source = source.to_s
+      if Source.exists?(source)
+        Source.new(source, opts)
+      elsif ZipSource.exists?(source)
+        ZipSource.new(source, opts)
+      elsif URLSource.exists?(source)
+        URLSource.new(source)
       else
-        src = URLSource.new(data_root, opts)
+        raise 'No handler for source'
       end
+    end
+
+    def self.exists?(source)
+      File.directory?(source)
     end
 
     private

--- a/lib/gtfs/url_source.rb
+++ b/lib/gtfs/url_source.rb
@@ -3,11 +3,11 @@ require 'uri'
 
 module GTFS
   class URLSource < ZipSource
-    def load_archive(source_path)
-      source_path, _, fragment = source_path.partition('#')
+    def load_archive(source)
+      source, _, fragment = source.partition('#')
       tmp_dir = Dir.mktmpdir
       source_file = File.join(tmp_dir, "/gtfs_temp_#{Time.now.strftime('%Y%jT%H%M%S%z')}.zip")
-      uri = URI.parse(source_path)
+      uri = URI.parse(source)
       response = Net::HTTP.get_response(uri)
       open(source_file, 'wb') do |file|
         file.write response.body

--- a/lib/gtfs/url_source.rb
+++ b/lib/gtfs/url_source.rb
@@ -18,5 +18,10 @@ module GTFS
     rescue Exception => e
       raise InvalidSourceException.new(e.message)
     end
+
+    def self.exists?(source)
+      source.start_with?('http')
+    end
+
   end
 end

--- a/lib/gtfs/zip_source.rb
+++ b/lib/gtfs/zip_source.rb
@@ -45,6 +45,11 @@ module GTFS
         .keys
     end
 
+    def self.exists?(source)
+      source, _, fragment = source.partition('#')
+      File.exists?(source)
+    end
+
     private
 
     def self.find_paths(filename, basepath: nil, limit: 1000, count: 0)

--- a/lib/rubyzip_time.rb
+++ b/lib/rubyzip_time.rb
@@ -1,0 +1,33 @@
+# Fix time-related behaviors in rubyzip.
+# 1. Read mtime into @time
+# 2. Extract writes mtime
+# 3. Write mtime *after* file is written
+
+module Zip
+  class Entry
+    def get_extra_attributes_from_path(path) # :nodoc:
+      return if Zip::RUNNING_ON_WINDOWS
+      stat        = file_stat(path)
+      @unix_uid   = stat.uid
+      @unix_gid   = stat.gid
+      @unix_perms = stat.mode & 07777
+      @time       = Zip::DOSTime.at(stat.mtime)
+    end
+
+    def set_unix_times_on_path(dest_path)
+      return unless @restore_times
+      FileUtils.touch(dest_path, mtime: @time)
+    end
+
+    def extract(dest_path = @name, &block)
+      block ||= proc { ::Zip.on_exists_proc }
+      if directory? || file? || symlink?
+        __send__("create_#{@ftype}", dest_path, &block)
+      else
+        raise "unknown file type #{inspect}"
+      end
+      set_unix_times_on_path(dest_path)
+      self
+    end
+  end
+end

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -141,15 +141,9 @@ describe GTFS::Source do
       path2 = File.join(tmp_dir, '2.zip')
       f1 = GTFS::Source.build(source_valid)
       f1.create_archive(path1)
-      sleep(10)
+      sleep(5)
       f2 = GTFS::Source.build(source_valid)
       f2.create_archive(path2)
-      [path1, path2].each do |path|
-        puts path
-        Zip::File.open(path) do |zip|
-          zip.entries.each { |entry| puts "#{entry.time} -- #{entry.name}" }
-        end
-      end
       sha1 = Digest::SHA1.file(path1).hexdigest
       sha2 = Digest::SHA1.file(path2).hexdigest
       sha1.should eq sha2

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -139,10 +139,10 @@ describe GTFS::Source do
       tmp_dir = Dir.mktmpdir
       path1 = File.join(tmp_dir, '1.zip')
       path2 = File.join(tmp_dir, '2.zip')
-      f1 = GTFS::Source.build(source_valid)
+      f1 = GTFS::Source.build(source_valid_zip)
       f1.create_archive(path1)
       sleep(5)
-      f2 = GTFS::Source.build(source_valid)
+      f2 = GTFS::Source.build(source_valid_zip)
       f2.create_archive(path2)
       sha1 = Digest::SHA1.file(path1).hexdigest
       sha2 = Digest::SHA1.file(path2).hexdigest

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -144,6 +144,13 @@ describe GTFS::Source do
       sleep(5)
       f2 = GTFS::Source.build(source_valid_zip)
       f2.create_archive(path2)
+      # Debugging
+      # [source_valid_zip, path1, path2].each do |path|
+      #   puts "\n\n===== #{path} ====="
+      #   Zip::File.open(path) do |zip|
+      #     zip.entries.each { |entry| puts "#{entry.time} -- #{entry.name}" }
+      #   end
+      # end
       sha1 = Digest::SHA1.file(path1).hexdigest
       sha2 = Digest::SHA1.file(path2).hexdigest
       sha1.should eq sha2

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -135,6 +135,27 @@ describe GTFS::Source do
       ]
     end
 
+    it 'creates stable sha1 across multiple extractions' do
+      tmp_dir = Dir.mktmpdir
+      path1 = File.join(tmp_dir, '1.zip')
+      path2 = File.join(tmp_dir, '2.zip')
+      f1 = GTFS::Source.build(source_valid)
+      f1.create_archive(path1)
+      sleep(10)
+      f2 = GTFS::Source.build(source_valid)
+      f2.create_archive(path2)
+      [path1, path2].each do |path|
+        puts path
+        Zip::File.open(path) do |zip|
+          zip.entries.each { |entry| puts "#{entry.time} -- #{entry.name}" }
+        end
+      end
+      sha1 = Digest::SHA1.file(path1).hexdigest
+      sha2 = Digest::SHA1.file(path2).hexdigest
+      sha1.should eq sha2
+      FileUtils.rm_rf(tmp_dir)
+    end
+
     it 'fails if file exists' do
       file = Tempfile.new('test.zip')
       path = file.path


### PR DESCRIPTION
Ensure timestamps are stable through extraction & compression of gtfs zip archives. This should allow the zip files of the same data to have relatively stable sha1 checksums (used for transitland file uniqueness).

Resolves #31 
Resolves #32
