### PR TITLE
Support FTP

### DIFF
--- a/lib/gtfs.rb
+++ b/lib/gtfs.rb
@@ -23,3 +23,4 @@ require 'gtfs/wide_time'
 require 'gtfs/fetch'
 
 require 'rubyzip_time'
+require 'open-uri'

--- a/lib/gtfs/fetch.rb
+++ b/lib/gtfs/fetch.rb
@@ -17,7 +17,6 @@ module GTFS
     private
 
     def self.request(url, limit: 10, timeout: 60, max_size: nil, progress_proc: nil, &block)
-      max_size ||= 1024*1024*5
       total = nil
       progress_proc ||= lambda { |count, total| }
       uri = URI.parse(url)

--- a/lib/gtfs/fetch.rb
+++ b/lib/gtfs/fetch.rb
@@ -3,17 +3,6 @@ require 'uri'
 
 module GTFS
   module Fetch
-    def self.download_to_tempfile(url, maxsize: nil, progress: nil)
-      file = Tempfile.new(['fetched-feed', '.zip'])
-      file.binmode
-      begin
-        request(url, max_size: maxsize, progress_proc: progress) { |io| FileUtils.cp(io, file) }
-        yield file.path
-      ensure
-        file.unlink
-      end
-    end
-
     def self.download(url, filename, maxsize: nil, progress: nil)
       request(
         url,

--- a/lib/gtfs/fetch.rb
+++ b/lib/gtfs/fetch.rb
@@ -5,6 +5,7 @@ module GTFS
   module Fetch
     def self.download_to_tempfile(url, maxsize: nil, progress: nil)
       file = Tempfile.new(['fetched-feed', '.zip'])
+      file.binmode
       begin
         request(url, max_size: maxsize, progress_proc: progress) { |io| FileUtils.cp(io, file) }
         yield file.path

--- a/lib/gtfs/fetch.rb
+++ b/lib/gtfs/fetch.rb
@@ -51,7 +51,7 @@ module GTFS
         raise ArgumentError.new('Too many redirects')
       end
       if io.is_a?(StringIO)
-        downloaded = Tempfile.new
+        downloaded = Tempfile.new('gtfs')
         File.write(downloaded.path, io.string)
       else
         downloaded = io

--- a/lib/gtfs/fetch.rb
+++ b/lib/gtfs/fetch.rb
@@ -9,7 +9,7 @@ module GTFS
         max_size: maxsize,
         progress_proc: progress
       ) { |io|
-        FileUtils.cp(io, filename)
+        FileUtils.copy_stream(io, filename)
       }
       filename
     end
@@ -39,13 +39,7 @@ module GTFS
         retry if (limit -= 1) > 0
         raise ArgumentError.new('Too many redirects')
       end
-      if io.is_a?(StringIO)
-        downloaded = Tempfile.new('gtfs')
-        File.write(downloaded.path, io.string)
-      else
-        downloaded = io
-      end
-      yield downloaded
+      yield io
     end
   end
 end

--- a/lib/gtfs/url_source.rb
+++ b/lib/gtfs/url_source.rb
@@ -19,7 +19,7 @@ module GTFS
     end
 
     def self.exists?(source)
-      ["http", "ftp"].include?(URI.parse(source).scheme)
+      ["http", "https", "ftp"].include?(URI.parse(source).scheme)
     end
   end
 end

--- a/lib/gtfs/url_source.rb
+++ b/lib/gtfs/url_source.rb
@@ -19,7 +19,7 @@ module GTFS
     end
 
     def self.exists?(source)
-      source.start_with?('http')
+      ["http", "ftp"].include?(URI.parse(source).scheme)
     end
   end
 end

--- a/spec/gtfs/fetch_spec.rb
+++ b/spec/gtfs/fetch_spec.rb
@@ -13,7 +13,7 @@ describe GTFS::Fetch do
     it 'returns a response' do
       VCR.use_cassette('fetch') do
         response = {}
-        GTFS::Fetch.request(url) { |resp| response = JSON.parse(resp.read_body) }
+        GTFS::Fetch.request(url) { |resp| response = JSON.parse(resp.read) }
         response['url'].should eq(url)
       end
     end
@@ -21,7 +21,7 @@ describe GTFS::Fetch do
     it 'follows a redirect' do
       VCR.use_cassette('fetch_redirect') do
         response = {}
-        GTFS::Fetch.request(url_redirect) { |resp| response = JSON.parse(resp.read_body) }
+        GTFS::Fetch.request(url_redirect) { |resp| response = JSON.parse(resp.read) }
         response['url'].should eq(url)
       end
     end
@@ -29,7 +29,7 @@ describe GTFS::Fetch do
     it 'follows a relative redirect' do
       VCR.use_cassette('fetch_redirect_relative') do
         response = {}
-        GTFS::Fetch.request(url_redirect_relative) { |resp| response = JSON.parse(resp.read_body) }
+        GTFS::Fetch.request(url_redirect_relative) { |resp| response = JSON.parse(resp.read) }
         response['url'].should eq(url)
       end
     end
@@ -37,7 +37,7 @@ describe GTFS::Fetch do
     it 'follows SSL' do
       VCR.use_cassette('fetch_ssl') do
         response = {}
-        GTFS::Fetch.request(url_ssl) { |resp| response = JSON.parse(resp.read_body) }
+        GTFS::Fetch.request(url_ssl) { |resp| response = JSON.parse(resp.read) }
         response['url'].should eq(url_ssl)
       end
     end
@@ -45,7 +45,7 @@ describe GTFS::Fetch do
     it 'follows a redirect no more than limit times' do
       VCR.use_cassette('fetch_redirect_fail') do
         expect {
-          GTFS::Fetch.request(url_redirect_many, limit:2) { |resp| response = JSON.parse(resp.read_body) }
+          GTFS::Fetch.request(url_redirect_many, limit:2) { |resp| response = JSON.parse(resp.read) }
         }.to raise_error(ArgumentError)
       end
     end
@@ -53,8 +53,8 @@ describe GTFS::Fetch do
     it 'raises errors' do
       VCR.use_cassette('fetch_fetch_404') do
         expect {
-          GTFS::Fetch.request(url_404, limit:2) { |resp| response = JSON.parse(resp.read_body) }
-        }.to raise_error(Net::HTTPServerException)
+          GTFS::Fetch.request(url_404, limit:2) { |resp| response = JSON.parse(resp.read) }
+        }.to raise_error(OpenURI::HTTPError)
       end
     end
   end


### PR DESCRIPTION
Support FTP.

Replaces Net::HTTP code with simpler calls to URI.parse(uri).open.

Moves a helper method to specs.

Resolves #51