### PR TITLE
option to include shape_dist_traveled with shape line

### DIFF
--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -136,8 +136,8 @@ module GTFS
       end
     end
 
-    def shape_line(shape_id)
-      self.load_shapes if @shape_lines.empty?
+    def shape_line(shape_id, include_shape_dist_traveled: false)
+      self.load_shapes(include_shape_dist_traveled: include_shape_dist_traveled) if @shape_lines.empty?
       @shape_lines[shape_id]
     end
 
@@ -205,7 +205,7 @@ module GTFS
       end
     end
 
-    def load_shapes
+    def load_shapes(include_shape_dist_traveled: false)
       # Merge shapes
       @shape_lines.clear
       # Return if missing shapes.txt
@@ -215,7 +215,7 @@ module GTFS
       shapes_merge.each do |k,v|
         @shape_lines[k] = v
           .sort_by { |i| i.shape_pt_sequence.to_i }
-          .map { |i| [i.shape_pt_lon.to_f, i.shape_pt_lat.to_f] }
+          .map { |i| include_shape_dist_traveled ? [[i.shape_pt_lon.to_f, i.shape_pt_lat.to_f], i.shape_dist_traveled.to_f] : [i.shape_pt_lon.to_f, i.shape_pt_lat.to_f] }
       end
       @shape_lines
     end

--- a/spec/gtfs/source_spec.rb
+++ b/spec/gtfs/source_spec.rb
@@ -217,6 +217,11 @@ describe GTFS::Source do
     it '#shape_line should returns array of points' do
       source.shape_line('63542').size.should be 9
     end
+
+    it 'returns shape_dist_traveled when include_shape_dist_traveled true' do
+      source.shape_line('63542', include_shape_dist_traveled: true).first[1].should eq 0.0
+      source.shape_line('63542', include_shape_dist_traveled: true).last[1].should eq 0.2572
+    end
   end
 
   describe '#load_service_periods' do


### PR DESCRIPTION
For the "shape_line" and "load_shapes" methods, adding keyword boolean arg "include_shape_dist_traveled" with default value false. If true, shape lines will be a nested array of shape point coord array and shape_dist_traveled float. 