### PR TITLE
ShapeLine Collection

### DIFF
--- a/lib/gtfs.rb
+++ b/lib/gtfs.rb
@@ -19,6 +19,7 @@ require 'gtfs/source'
 require 'gtfs/zip_source'
 require 'gtfs/url_source'
 require 'gtfs/service_period'
+require 'gtfs/shape_line'
 require 'gtfs/wide_time'
 require 'gtfs/fetch'
 

--- a/lib/gtfs/shape_line.rb
+++ b/lib/gtfs/shape_line.rb
@@ -1,0 +1,38 @@
+module GTFS
+  class ShapeLine
+    include Enumerable
+    attr_accessor :shapes
+
+    def self.from_shapes(shapes)
+      self.new(shapes.sort_by { |i| i.shape_pt_sequence.to_i })
+    end
+
+    def initialize(shapes=nil)
+      @shapes = shapes || []
+    end
+
+    def shape(index)
+      @shapes[index]
+    end
+
+    def each_shape(&block)
+      @shapes.each(&block)
+    end
+
+    def coordinates
+      @shapes.map { |i| [i.shape_pt_lon.to_f, i.shape_pt_lat.to_f] }
+    end
+
+    def shape_dist_traveled
+      @shapes.map { |i| i.shape_dist_traveled.to_f }
+    end
+
+    def each(&block)
+      coordinates.each(&block)
+    end
+
+    def size
+      @shapes.size
+    end
+  end
+end

--- a/lib/gtfs/shape_line.rb
+++ b/lib/gtfs/shape_line.rb
@@ -1,13 +1,14 @@
 module GTFS
   class ShapeLine
     include Enumerable
-    attr_accessor :shapes
+    attr_accessor :shape_id, :shapes
 
     def self.from_shapes(shapes)
-      self.new(shapes.sort_by { |i| i.shape_pt_sequence.to_i })
+      self.new(shapes.first.shape_id, shapes.sort_by { |i| i.shape_pt_sequence.to_i })
     end
 
-    def initialize(shapes=nil)
+    def initialize(shape_id=nil, shapes=nil)
+      @shape_id = shape_id
       @shapes = shapes || []
     end
 

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -213,9 +213,7 @@ module GTFS
       shapes_merge = Hash.new { |h,k| h[k] = [] }
       self.each_shape { |e| shapes_merge[e.shape_id] << e }
       shapes_merge.each do |k,v|
-        @shape_lines[k] = v
-          .sort_by { |i| i.shape_pt_sequence.to_i }
-          .map { |i| [i.shape_pt_lon.to_f, i.shape_pt_lat.to_f] }
+        @shape_lines[k] = ShapeLine.from_shapes(v)
       end
       @shape_lines
     end

--- a/spec/gtfs/shape_line_spec.rb
+++ b/spec/gtfs/shape_line_spec.rb
@@ -4,13 +4,87 @@ describe GTFS::ShapeLine do
   let(:valid_local_source) do
     File.expand_path(File.dirname(__FILE__) + '/../fixtures/valid_gtfs.zip')
   end
+  let(:shapes) {[
+      GTFS::Shape.new(shape_id: '63542', shape_pt_sequence: '5', shape_pt_lon: "-76.662018", shape_pt_lat: "39.350739", shape_dist_traveled: "0.1631"),
+      GTFS::Shape.new(shape_id: '63542', shape_pt_sequence: '4', shape_pt_lon: "-76.661949", shape_pt_lat: "39.35067", shape_dist_traveled: "0.1539"),
+      GTFS::Shape.new(shape_id: '63542', shape_pt_sequence: '3', shape_pt_lon: "-76.660767", shape_pt_lat: "39.350719", shape_dist_traveled: "0.0517"),
+      GTFS::Shape.new(shape_id: '63542', shape_pt_sequence: '2', shape_pt_lon: "-76.6605", shape_pt_lat: "39.350742", shape_dist_traveled: "0.0286"),
+      GTFS::Shape.new(shape_id: '63542', shape_pt_sequence: '1', shape_pt_lon: "-76.660172", shape_pt_lat: "39.350792", shape_dist_traveled: "0.0"),
+  ]}
+  let(:shape_line) { GTFS::ShapeLine.from_shapes(shapes) }
 
-  describe 'test' do
+  context 'load_shapes' do
     let(:data_source) {valid_local_source}
     let(:opts) {{}}
-
     it 'has a ShapeLine' do
+      source = GTFS::ZipSource.new(data_source, opts)
+      source.load_shapes
+      sl = source.shape_line('63542')
+      sl.shape_id.should eq('63542')
+    end
+  end
 
+  context '.from_shapes' do
+    it 'creates ShapeLine from shapes' do
+      sl = GTFS::ShapeLine.from_shapes(shapes)
+      sl.shape_id.should eq('63542')
+      sl.coordinates.size.should eq(5)
+      sl.coordinates[0][0].should be_within(0.01).of(-76.660172)
+      sl.coordinates[0][1].should be_within(0.01).of(39.350792)
+      sl.shape_dist_traveled.size.should eq(5)
+      sl.shape_dist_traveled[0].should be_within(0.01).of(0.0)
+      sl.shape_dist_traveled[-1].should be_within(0.01).of(0.1631)
+    end
+  end
+
+  context '#size' do
+    it 'returns shape size' do
+      shape_line.size.should eq(5)
+    end
+  end
+
+  context '#coordinates' do
+    it 'returns shape coordinates' do
+      shape_line.coordinates.size.should eq(5)
+      shape_line.coordinates[0][0].should be_within(0.01).of(-76.660172)
+      shape_line.coordinates[0][1].should be_within(0.01).of(39.350792)
+    end
+  end
+
+  context '#shape_dist_traveled' do
+    it 'returns shape_dist_traveled' do
+      shape_line.shape_dist_traveled.size.should eq(5)
+      shape_line.shape_dist_traveled[0].should be_within(0.01).of(0.0)
+      shape_line.shape_dist_traveled[-1].should be_within(0.01).of(0.1631)
+    end
+  end
+
+  context '#shape' do
+    it 'returns shape index' do
+      shape_line.shape(0).should eq(shapes.sort_by { |i| i.shape_pt_sequence.to_i }[0])
+    end
+  end
+
+  context '#each_shape' do
+    it 'iterates through shapes' do
+      count = 0
+      shape_line.each_shape { |i| count += 1 }
+      count.should eq(5)
+    end
+  end
+
+  context '#each' do
+    it 'iterates through coordinates' do
+      count = 0
+      shape_line.each { |i| count += 1 }
+      count.should eq(5)
+    end
+  end
+
+  context 'Enumerable' do
+    it 'supports map' do
+      result = shape_line.map { |i| true }
+      result.should eq([true]*5)
     end
   end
 end

--- a/spec/gtfs/shape_line_spec.rb
+++ b/spec/gtfs/shape_line_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
+
+describe GTFS::ShapeLine do
+  let(:valid_local_source) do
+    File.expand_path(File.dirname(__FILE__) + '/../fixtures/valid_gtfs.zip')
+  end
+
+  describe 'test' do
+    let(:data_source) {valid_local_source}
+    let(:opts) {{}}
+
+    it 'has a ShapeLine' do
+
+    end
+  end
+end


### PR DESCRIPTION
New class, `ShapeLine`, to act as  a collection of `Shape` points. Replaces a simple array of lon/lat coords. Provides `coordinates` and `shape_dist_traveled` methods.

Note: Source.shape_line now returns ShapeLines instead of coordinate arrays.