### PR TITLE
GTFS Entities: add a sort comparison method 

### DIFF
--- a/lib/gtfs/model.rb
+++ b/lib/gtfs/model.rb
@@ -21,6 +21,10 @@ module GTFS
       def id
       end
 
+      def <=>(other)
+        id <=> other.id
+      end
+
       def name
       end
 

--- a/lib/gtfs/source.rb
+++ b/lib/gtfs/source.rb
@@ -199,15 +199,15 @@ module GTFS
         trip = self.trip(stop_time.trip_id)
         stop = self.stop(stop_time.stop_id)
         trip_stop_sequence[trip] ||= []
-        trip_stop_sequence[trip] << [stop_time.stop_sequence.to_i, stop, stop_time.shape_dist_traveled]
+        trip_stop_sequence[trip] << [stop_time.stop_sequence.to_i, stop_time.shape_dist_traveled, stop]
         @trip_counter[trip] += 1
         count += 1
         progress_block.call(count, total, nil)
       end
       trip_stop_sequence.each do |trip, seq|
         seq = seq.sort
-        trip.stop_sequence = seq.map { |i| i[1] }
-        trip.shape_dist_traveled = seq.map { |i| i[2] }
+        trip.shape_dist_traveled = seq.map { |i| i[1] }
+        trip.stop_sequence = seq.map { |i| i[2] }
       end
     end
 


### PR DESCRIPTION
Add a sort comparison method for sorting GTFS entities.

The issue came up when a feed had a stop_times.txt table with multiple rows with the same stop_sequence value. It then attempted to sort by Stop instances, which failed.

Related to: https://github.com/transitland/transitland/issues/252

Resolves #72